### PR TITLE
Streaming ETL improvements

### DIFF
--- a/code/us-stock-analysis/project/build.properties
+++ b/code/us-stock-analysis/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.16
+sbt.version=0.13.17

--- a/code/us-stock-analysis/src/main/scala/es/arjon/FakeStockPriceGenerator.scala
+++ b/code/us-stock-analysis/src/main/scala/es/arjon/FakeStockPriceGenerator.scala
@@ -7,8 +7,6 @@ import org.apache.kafka.clients.producer.{KafkaProducer, ProducerRecord}
 
 object FakeStockPriceGenerator extends App {
   val rnd = new scala.util.Random(42)
-  // This is when Dataset ends
-  // var tradingBeginOfTime = ZonedDateTime.parse("2017-11-11T10:00:00Z")
 
   if (args.length < 2 || args.length > 3) {
     System.err.println(
@@ -25,6 +23,7 @@ object FakeStockPriceGenerator extends App {
 
   val brokers = args(0)
   val topic = args(1)
+  // Default date is when Batch dataset ends
   val tradingStartParam = if (args.length == 3) args(2) else "2017-11-11T10:00:00Z"
 
   var tradingBeginOfTime = ZonedDateTime.parse(tradingStartParam)

--- a/code/us-stock-analysis/src/main/scala/es/arjon/FakeStockPriceGenerator.scala
+++ b/code/us-stock-analysis/src/main/scala/es/arjon/FakeStockPriceGenerator.scala
@@ -8,21 +8,26 @@ import org.apache.kafka.clients.producer.{KafkaProducer, ProducerRecord}
 object FakeStockPriceGenerator extends App {
   val rnd = new scala.util.Random(42)
   // This is when Dataset ends
-  var tradingBeginOfTime = ZonedDateTime.parse("2017-11-11T10:00:00Z")
+  // var tradingBeginOfTime = ZonedDateTime.parse("2017-11-11T10:00:00Z")
 
-  if (args.length < 2) {
+  if (args.length < 2 || args.length > 3) {
     System.err.println(
       s"""
-         |Usage: FakeStockPriceGenerator <brokers> <topics>
+         |Usage: FakeStockPriceGenerator <brokers> <topics> <start_date>
          |  <brokers> is a list of one or more Kafka brokers
          |  <topic> one kafka topic to produce to
+         |  <start_date> [OPTIONAL] iso timestamp from when to start producing data
          |
-         |  FakeStockPriceGenerator kafka:9092 stocks
+         |  FakeStockPriceGenerator kafka:9092 stocks 2017-11-11T10:00:00Z
         """.stripMargin)
     System.exit(1)
   }
 
-  val Array(brokers, topic) = args
+  val brokers = args(0)
+  val topic = args(1)
+  val tradingStartParam = if (args.length == 3) args(2) else "2017-11-11T10:00:00Z"
+
+  var tradingBeginOfTime = ZonedDateTime.parse(tradingStartParam)
 
   println(
     s"""
@@ -58,6 +63,7 @@ object FakeStockPriceGenerator extends App {
     // not consider weekends nor holidays
     def nextMarketTime = {
       val tick = 3
+      // TODO: add ability to generate out of order data
       val proposedNextTime = tradingBeginOfTime.plusMinutes(tick)
       val nextTime = if (proposedNextTime.getHour > 15)
         proposedNextTime.plusDays(1).withHour(10).withMinute(0)

--- a/code/us-stock-analysis/src/main/scala/es/arjon/StreamingETL.scala
+++ b/code/us-stock-analysis/src/main/scala/es/arjon/StreamingETL.scala
@@ -75,8 +75,8 @@ object StreamingETL extends App {
     trigger(Trigger.ProcessingTime("30 seconds")).
     start()
 
-  // There is no JDBC sink for now!
-  // https://databricks.com/blog/2017/04/04/real-time-end-to-end-integration-with-apache-kafka-in-apache-sparks-structured-streaming.html
+  //TODO: use ForEachBatch to write to Postgres in Append mode
+  // https://spark.apache.org/docs/latest/structured-streaming-programming-guide.html#foreachbatch
 
   // Using as an ordinary DF
   val avgPricing = stocks.


### PR DESCRIPTION
1. [x] Upgraded sbt version to 0.13.17 so it works with Scala 2.11.12
2. [x] Added optional `start_date` argument to FakeStockPriceGenerator
3. [ ] Use ForEachBatch to write to Postgres
4. [ ] Enable generating out of order data.